### PR TITLE
fix: [FatSecretApiClientTest] 토큰 전송 테스트 fail 문제 해결

### DIFF
--- a/src/test/java/com/hotnerds/fatsecret/application/FatSecretApiClientTest.java
+++ b/src/test/java/com/hotnerds/fatsecret/application/FatSecretApiClientTest.java
@@ -143,11 +143,10 @@ class FatSecretApiClientTest {
         mockServer.expect(requestTo(requestURL))
                 .andExpect(header("Authorization", "Bearer valid token"))
                 .andRespond(withNoContent());
+        when(fatSecretToken.getToken()).thenReturn("valid token");
 
-        //when
-        fatSecretApiClient.searchFoodById(38821L);
-
-        //then
+        //when then
+        assertDoesNotThrow(() -> fatSecretApiClient.searchFoodById(38821L));
 
     }
 
@@ -159,11 +158,10 @@ class FatSecretApiClientTest {
         mockServer.expect(requestTo(requestURL))
                 .andExpect(header("Authorization", "Bearer valid token"))
                 .andRespond(withNoContent());
+        when(fatSecretToken.getToken()).thenReturn("valid token");
 
-        //when
-        fatSecretApiClient.searchFoods("Chicken", 0, 5);
-
-        //then
+        //when then
+        assertDoesNotThrow(() -> fatSecretApiClient.searchFoods("Chicken", 0, 5));
 
     }
 


### PR DESCRIPTION
* resolved: #33 
* 문제 현상
  - FatSecretApiClientTest 코드를 실행했을때 토큰 관련 테스트에서 Fail이 발생한다.
* 문제 원인
  - FatSecretApiToken 객체가 Mock 객체이기 때문에 FatSecretApiClient에서 getToken을 호출 시 Null값이 반환된다.
* 문제 해결
  - FatSecretApiToken.getToken 함수를 mocking하여 올바른 토큰을 가져올 수 있도록 한다.