### PR TITLE
fix: [ControllerTest] ComponentScan을 통해 Security Config에 필요했던 Bean을 Mock 객체가 아닌 실제로 Bean을 불러서 사용하도록 변경.

### DIFF
--- a/src/main/java/com/hotnerds/common/security/OAuth2Config.java
+++ b/src/main/java/com/hotnerds/common/security/OAuth2Config.java
@@ -1,4 +1,4 @@
-package com.hotnerds.common;
+package com.hotnerds.common.security;
 
 import com.hotnerds.common.security.oauth2.provider.CustomOAuth2Provider;
 import com.hotnerds.common.security.oauth2.resolver.AuthenticatedUserMethodArgumentResolver;

--- a/src/test/java/com/hotnerds/ControllerTest.java
+++ b/src/test/java/com/hotnerds/ControllerTest.java
@@ -14,6 +14,7 @@ import com.hotnerds.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -28,6 +29,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+@ComponentScan(basePackages = "com.hotnerds.common.security")
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 public class ControllerTest {
 
@@ -38,45 +40,23 @@ public class ControllerTest {
     @MockBean
     protected UserRepository userRepository;
 
-    @MockBean
-    protected JwtTokenProvider jwtTokenProvider;
-
-    @MockBean
-    AuthenticatedUserMethodArgumentResolver resolver;
-
-    @MockBean
-    CustomOAuth2UserService customOAuth2UserService;
-
-    @MockBean
-    OAuth2SuccessHandler oAuth2SuccessHandler;
-
-    @MockBean
-    OAuth2AuthenticationEntryPoint oAuth2AuthenticationEntryPoint;
 
     protected MockMvc mockMvc;
 
     protected ObjectMapper objectMapper;
 
-    @BeforeEach
-    protected void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) throws Exception {
-        JwtAuthenticationFilter jwtAuthenticationFilter = (JwtAuthenticationFilter) webApplicationContext.getBean("jwtAuthenticationFilter");
+        @BeforeEach
+        protected void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) throws Exception {
+            JwtAuthenticationFilter jwtAuthenticationFilter = (JwtAuthenticationFilter) webApplicationContext.getBean("jwtAuthenticationFilter");
 
-        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .addFilter(new CharacterEncodingFilter("UTF-8", true))
-                .addFilter(jwtAuthenticationFilter)
-                .apply(springSecurity())
-                .apply(documentationConfiguration(restDocumentation))
-                .alwaysDo(print())
-                .build();
+            mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                    .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                    .addFilter(jwtAuthenticationFilter)
+                    .apply(springSecurity())
+                    .apply(documentationConfiguration(restDocumentation))
+                    .alwaysDo(print())
+                    .build();
 
-        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-
-        User user = User.builder()
-                .email(USER_EMAIL)
-                .username("garamkim")
-                .build();
-
-        when(resolver.supportsParameter(any())).thenReturn(true);
-        when(resolver.resolveArgument(any(), any(), any(), any())).thenReturn(AuthenticatedUser.of(user));
+            objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
     }
 }


### PR DESCRIPTION
## 구현 기능들
- [ ] Controller Test Component Scan 범위 Security 폴더를 포함하도록 변경
- [ ] 기존의 Mock으로 주입한 Security Field들 제거.
- [ ] OAuthConfig 폴더 위치 common.security 안으로 이동.
## 참고 사항
-
Close #64 