### PR TITLE
Fix/helenee 66

### DIFF
--- a/src/main/java/com/hotnerds/common/security/oauth2/resolver/AuthenticatedUserMethodArgumentResolver.java
+++ b/src/main/java/com/hotnerds/common/security/oauth2/resolver/AuthenticatedUserMethodArgumentResolver.java
@@ -24,7 +24,7 @@ public class AuthenticatedUserMethodArgumentResolver implements HandlerMethodArg
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(Authenticated.class) &&
-                User.class.isAssignableFrom(parameter.getParameterType());
+                AuthenticatedUser.class.isAssignableFrom(parameter.getParameterType());
     }
 
     @Override

--- a/src/test/java/com/hotnerds/ControllerTest.java
+++ b/src/test/java/com/hotnerds/ControllerTest.java
@@ -7,8 +7,10 @@ import com.hotnerds.common.security.handler.OAuth2AuthenticationEntryPoint;
 import com.hotnerds.common.security.handler.OAuth2SuccessHandler;
 import com.hotnerds.common.security.oauth2.provider.JwtTokenProvider;
 import com.hotnerds.common.security.oauth2.resolver.AuthenticatedUserMethodArgumentResolver;
+import com.hotnerds.common.security.oauth2.service.AuthProvider;
 import com.hotnerds.common.security.oauth2.service.AuthenticatedUser;
 import com.hotnerds.common.security.oauth2.service.CustomOAuth2UserService;
+import com.hotnerds.user.domain.ROLE;
 import com.hotnerds.user.domain.User;
 import com.hotnerds.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +24,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -40,6 +44,7 @@ public class ControllerTest {
     @MockBean
     protected UserRepository userRepository;
 
+    protected User user;
 
     protected MockMvc mockMvc;
 
@@ -58,5 +63,9 @@ public class ControllerTest {
                     .build();
 
             objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+            user = new User("garamkim", "kgr4163@naver.com", ROLE.USER, AuthProvider.KAKAO);
+
+            when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
     }
 }

--- a/src/test/java/com/hotnerds/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/hotnerds/WithMockCustomUserSecurityContextFactory.java
@@ -25,7 +25,7 @@ public class WithMockCustomUserSecurityContextFactory implements WithSecurityCon
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put(USER_EMAIL, annotation.getEmail());
-        attributes.put(NAME_ATTRIBUTE_KEY, "1L");
+        attributes.put(NAME_ATTRIBUTE_KEY, annotation.getNameAttributeKey());
 
         DefaultOAuth2User oAuth2User = new DefaultOAuth2User(Collections.singleton(new SimpleGrantedAuthority(ROLE.USER.getKey())), attributes,
                 annotation.getNameAttributeKey());


### PR DESCRIPTION
## 구현 기능들
- [ ] AuthenticatedUserMethodArgumentResolver의 supportParameter 메서드에서 할당할 수 있는 클래스 타입을 AuthenticatedUser로 변경한다.
- [ ]  ControllerTest에서 UserRepository mock 객체의 행위를 정의한다.
## 참고 사항
-
Close #66 